### PR TITLE
Fix corrupt app manifests

### DIFF
--- a/UFS2Tool.GUI/app.manifest
+++ b/UFS2Tool.GUI/app.manifest
@@ -1,6 +1,3 @@
-<!-- Copyright (c) 2026, SvenGDK -->
-<!-- Licensed under the BSD 2-Clause License. See LICENSE file for details. -->
-
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- This manifest is used on Windows only.

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,3 @@
-<!-- Copyright (c) 2026, SvenGDK -->
-<!-- Licensed under the BSD 2-Clause License. See LICENSE file for details. -->
-
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="Ufs2Tool"/>


### PR DESCRIPTION
The windows builds can't start now, because the app.manifest's xml is invalid due to the license header, it needs to start with the xml tag