### PR TITLE
Fix race condition in content browser subfolder expansion

### DIFF
--- a/UFS2Tool.GUI/ViewModels/ContentBrowserViewModel.cs
+++ b/UFS2Tool.GUI/ViewModels/ContentBrowserViewModel.cs
@@ -155,7 +155,7 @@ public partial class ContentBrowserViewModel(ObservableCollection<string> output
                 }
             });
 
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
                 node.Children.Clear();
                 foreach (var child in children)


### PR DESCRIPTION
Simple change to task handling to prevent race condition that made opening folders often fail.  The event wasn't getting attached to the UI.  Should fix #7 