### PR TITLE
Change file reading from byte arrays to streams

### DIFF
--- a/UFS2Tool.Tests/BitmapAndLinkCountTests.cs
+++ b/UFS2Tool.Tests/BitmapAndLinkCountTests.cs
@@ -1111,9 +1111,14 @@ namespace UFS2Tool.Tests
                 if (e.FileType != Ufs2Constants.DtReg) continue;
                 if (!e.Name.StartsWith("file_") || !e.Name.EndsWith(".txt")) continue;
                 int idx = int.Parse(e.Name.Substring("file_".Length, e.Name.Length - "file_".Length - ".txt".Length));
-                byte[] data = image.ReadFile(e.Inode);
+                byte[] data = image.ReadFileBytes(e.Inode);
                 string content = System.Text.Encoding.UTF8.GetString(data);
                 Assert.Equal($"content_{idx}_data", content);
+
+                // stream test
+                using var msEntry = new ValidationWriteStream(data);
+                image.ReadFile(e.Inode, msEntry);
+                msEntry.AssertComplete();
             }
 
             // Verify binary file content
@@ -1122,8 +1127,13 @@ namespace UFS2Tool.Tests
             var subEntries = image.ListDirectory(subEntry.Inode);
             var binEntry = subEntries.Find(e => e.Name == "binary.bin");
             Assert.NotNull(binEntry);
-            byte[] readData = image.ReadFile(binEntry.Inode);
+            byte[] readData = image.ReadFileBytes(binEntry.Inode);
             Assert.Equal(binaryData, readData);
+
+            // stream test
+            using var ms = new ValidationWriteStream(binaryData);
+            image.ReadFile(binEntry.Inode, ms);
+            ms.AssertComplete();
         }
     }
 }

--- a/UFS2Tool.Tests/GrowFsTests.cs
+++ b/UFS2Tool.Tests/GrowFsTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026, SvenGDK
 // Licensed under the BSD 2-Clause License. See LICENSE file for details.
 
+using static System.Net.Mime.MediaTypeNames;
+
 namespace UFS2Tool.Tests
 {
     /// <summary>
@@ -142,6 +144,8 @@ namespace UFS2Tool.Tests
         [Fact]
         public void GrowFs_PreservesExistingFiles()
         {
+            byte[] readDataFromStream = new byte[5000];
+
             // Create an image with files
             string testDir = Path.Combine(Path.GetTempPath(), $"ufs2growfs_dir_{Guid.NewGuid():N}");
             Directory.CreateDirectory(testDir);
@@ -173,9 +177,14 @@ namespace UFS2Tool.Tests
 
                 // Verify file content
                 var helloInode = entries.Find(e => e.Name == "hello.txt")!.Inode;
-                byte[] content = verify.ReadFile(helloInode);
+                byte[] content = verify.ReadFileBytes(helloInode);
                 string text = System.Text.Encoding.UTF8.GetString(content).TrimEnd('\0');
                 Assert.Contains("Hello from growfs test!", text);
+
+                // stream test
+                using var msEntry = new ValidationWriteStream(content);
+                verify.ReadFile(helloInode, msEntry);
+                msEntry.AssertComplete();
             }
             finally
             {

--- a/UFS2Tool.Tests/NewfsComplianceTests.cs
+++ b/UFS2Tool.Tests/NewfsComplianceTests.cs
@@ -410,9 +410,14 @@ namespace UFS2Tool.Tests
                 // Verify large file
                 var rootEntries = image.ListRoot();
                 var largeEntry = rootEntries.First(e => e.Name == "large.bin");
-                byte[] readData = image.ReadFile(largeEntry.Inode);
+                byte[] readData = image.ReadFileBytes(largeEntry.Inode);
                 Assert.Equal(largeData.Length, readData.Length);
                 Assert.Equal(largeData, readData);
+
+                // stream test
+                using var ms = new ValidationWriteStream(readData);
+                image.ReadFile(largeEntry.Inode, ms);
+                ms.AssertComplete();
 
                 // Verify all subdirectories and nested content
                 for (int i = 0; i < 5; i++)

--- a/UFS2Tool.Tests/NewfsDOptionTests.cs
+++ b/UFS2Tool.Tests/NewfsDOptionTests.cs
@@ -298,10 +298,15 @@ namespace UFS2Tool.Tests
             var rootEntries = image.ListRoot();
             var fileEntry = rootEntries.First(e => e.Name == "hello.txt");
 
-            byte[] fileData = image.ReadFile(fileEntry.Inode);
+            byte[] fileData = image.ReadFileBytes(fileEntry.Inode);
             string readContent = System.Text.Encoding.UTF8.GetString(fileData);
 
             Assert.Equal(content, readContent);
+
+            // stream test
+            using var ms = new ValidationWriteStream(fileData);
+            image.ReadFile(fileEntry.Inode, ms);
+            ms.AssertComplete();
         }
 
         [Fact]
@@ -322,9 +327,14 @@ namespace UFS2Tool.Tests
             var rootEntries = image.ListRoot();
             var fileEntry = rootEntries.First(e => e.Name == "binary.dat");
 
-            byte[] readData = image.ReadFile(fileEntry.Inode);
+            byte[] readData = image.ReadFileBytes(fileEntry.Inode);
             Assert.Equal(originalData.Length, readData.Length);
             Assert.Equal(originalData, readData);
+
+            // stream test
+            using var ms = new ValidationWriteStream(readData);
+            image.ReadFile(fileEntry.Inode, ms);
+            ms.AssertComplete();
         }
 
         [Fact]
@@ -508,8 +518,14 @@ namespace UFS2Tool.Tests
 
             // Verify file content is preserved
             var fileEntry = rootEntries.First(e => e.Name == "file1.txt");
-            string content = System.Text.Encoding.UTF8.GetString(image.ReadFile(fileEntry.Inode));
+            byte[] data = image.ReadFileBytes(fileEntry.Inode);
+            string content = System.Text.Encoding.UTF8.GetString(data);
             Assert.Equal("hello world", content);
+
+            // stream test
+            using var ms = new ValidationWriteStream(data);
+            image.ReadFile(fileEntry.Inode, ms);
+            ms.AssertComplete();
         }
 
         [Fact]
@@ -559,8 +575,14 @@ namespace UFS2Tool.Tests
 
             // Verify file content at leaf
             var deepFile = entries.First(e => e.Name == "deep.txt");
-            string content = System.Text.Encoding.UTF8.GetString(image.ReadFile(deepFile.Inode));
+            byte[] data = image.ReadFileBytes(deepFile.Inode);
+            string content = System.Text.Encoding.UTF8.GetString(data);
             Assert.Equal("deep content", content);
+
+            // stream test
+            using var ms = new ValidationWriteStream(data);
+            image.ReadFile(deepFile.Inode, ms);
+            ms.AssertComplete();
         }
 
         [Fact]
@@ -653,8 +675,14 @@ namespace UFS2Tool.Tests
 
                 // Verify file content
                 var fileEntry = dirEntries.First(e => e.Name == $"file_at_level{i}.txt");
-                string content = System.Text.Encoding.UTF8.GetString(image.ReadFile(fileEntry.Inode));
+                var data = image.ReadFileBytes(fileEntry.Inode);
+                string content = System.Text.Encoding.UTF8.GetString(data);
                 Assert.Equal($"Content at level {i}", content);
+
+                // stream test
+                using var ms = new ValidationWriteStream(data);
+                image.ReadFile(fileEntry.Inode, ms);
+                ms.AssertComplete();
 
                 currentDirInode = levelDir.Inode;
             }
@@ -694,8 +722,13 @@ namespace UFS2Tool.Tests
             {
                 string expectedName = $"item_{i:D04}.txt";
                 var entry = fileEntries.First(e => e.Name == expectedName);
-                byte[] data = image.ReadFile(entry.Inode);
+                byte[] data = image.ReadFileBytes(entry.Inode);
                 Assert.Equal($"data_{i}", System.Text.Encoding.UTF8.GetString(data));
+
+                // stream test
+                using var ms = new ValidationWriteStream(data);
+                image.ReadFile(entry.Inode, ms);
+                ms.AssertComplete();
             }
 
             // Verify directory "." and ".." entries
@@ -726,13 +759,24 @@ namespace UFS2Tool.Tests
             // Verify large file content
             var rootEntries = image.ListRoot();
             var largeEntry = rootEntries.First(e => e.Name == "large.bin");
-            byte[] readData = image.ReadFile(largeEntry.Inode);
+            byte[] readData = image.ReadFileBytes(largeEntry.Inode);
             Assert.Equal(largeData.Length, readData.Length);
             Assert.Equal(largeData, readData);
 
+            // stream test
+            using var ms = new ValidationWriteStream(readData);
+            image.ReadFile(largeEntry.Inode, ms);
+            ms.AssertComplete();
+
             // Verify small file content
             var smallEntry = rootEntries.First(e => e.Name == "small.txt");
-            Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(image.ReadFile(smallEntry.Inode)));
+            var data = image.ReadFileBytes(smallEntry.Inode);
+            Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(data));
+
+            // stream test
+            using var ms2 = new ValidationWriteStream(data);
+            image.ReadFile(smallEntry.Inode, ms2);
+            ms2.AssertComplete();
 
             // Verify inode has indirect block pointer set
             var inode = image.ReadInode(largeEntry.Inode);

--- a/UFS2Tool.Tests/ValidationWriteStream.cs
+++ b/UFS2Tool.Tests/ValidationWriteStream.cs
@@ -1,0 +1,50 @@
+﻿namespace UFS2Tool.Tests
+{
+    public class ValidationWriteStream : Stream
+    {
+        private readonly byte[] _expectedData;
+        private long _position;
+
+        public ValidationWriteStream(byte[] expectedData)
+        {
+            _expectedData = expectedData ?? throw new ArgumentNullException(nameof(expectedData));
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                long currentPos = _position + i;
+
+                // Assert if trying to overflow
+                Assert.True(currentPos < _expectedData.Length,
+                    $"Function attempted to write past the expected length of {_expectedData.Length} bytes.");
+
+                byte actualByte = buffer[offset + i];
+                byte expectedByte = _expectedData[currentPos];
+
+                // Assert if received byte is not expected value
+                Assert.Equal(expectedByte, actualByte);
+            }
+
+            _position += count;
+        }
+
+        public void AssertComplete()
+        {
+            // Assert if we did not test entire array
+            Assert.Equal(_expectedData.Length, _position);
+        }
+
+        // Required Stream boilerplate overrides
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _position;
+        public override long Position { get => _position; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Flush() { }
+    }
+}

--- a/Ufs2DokanOperations.cs
+++ b/Ufs2DokanOperations.cs
@@ -165,23 +165,36 @@ namespace UFS2Tool
             if (inode == null)
                 return DokanResult.FileNotFound;
 
-            byte[] fileData;
-            lock (_lock)
+            try
             {
-                var inodeData = _image.ReadInode(inode.Value);
-                if (!inodeData.IsRegularFile && !inodeData.IsSymlink)
-                    return DokanResult.AccessDenied;
+                lock (_lock)
+                {
+                    var inodeData = _image.ReadInode(inode.Value);
+                    if (!inodeData.IsRegularFile && !inodeData.IsSymlink)
+                        return DokanResult.AccessDenied;
 
-                fileData = _image.ReadFile(inode.Value);
-            }
+                    if (offset >= inodeData.Size || buffer.Length == 0)
+                        return DokanResult.Success;
 
-            if (offset >= fileData.Length)
+                    long toRead = Math.Min(buffer.Length, inodeData.Size - offset);
+                    using var destination = new MemoryStream(buffer, 0, (int)toRead, writable: true, publiclyVisible: true);
+                    bytesRead = (int)_image.ReadFile(inode.Value, destination, offset, toRead, bufferSize: buffer.Length);
+                }
+
                 return DokanResult.Success;
-
-            int toRead = (int)Math.Min(buffer.Length, fileData.Length - offset);
-            Buffer.BlockCopy(fileData, (int)offset, buffer, 0, toRead);
-            bytesRead = toRead;
-            return DokanResult.Success;
+            }
+            catch (InvalidOperationException)
+            {
+                return DokanResult.AccessDenied;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return DokanResult.InvalidParameter;
+            }
+            catch (IOException)
+            {
+                return DokanResult.Error;
+            }
         }
 
         public NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten,
@@ -208,7 +221,7 @@ namespace UFS2Tool
                         return DokanResult.AccessDenied;
 
                     // Read existing file data, apply the write, then replace
-                    byte[] existingData = _image.ReadFile(inode.Value);
+                    byte[] existingData = _image.ReadFileBytes(inode.Value);
                     long newSize = Math.Max(existingData.Length, offset + buffer.Length);
                     if (newSize > int.MaxValue)
                         return DokanResult.InvalidParameter;
@@ -560,7 +573,7 @@ namespace UFS2Tool
                 lock (_lock)
                 {
                     string ufsPath = NormalizePath(fileName);
-                    byte[] existingData = _image.ReadFile(inode.Value);
+                    byte[] existingData = _image.ReadFileBytes(inode.Value);
                     byte[] newData = new byte[(int)length];
                     Buffer.BlockCopy(existingData, 0, newData, 0, Math.Min(existingData.Length, (int)length));
                     _image.ReplaceFileContent(ufsPath, newData);

--- a/Ufs2Image.cs
+++ b/Ufs2Image.cs
@@ -242,18 +242,87 @@ namespace UFS2Tool
         /// <summary>
         /// Read the contents of a regular file or symlink by inode number.
         /// </summary>
-        public byte[] ReadFile(uint inodeNumber)
+        public byte[] ReadFileBytes(uint inodeNumber)
         {
             var inode = ReadInode(inodeNumber);
             if (!inode.IsRegularFile && !inode.IsSymlink)
                 throw new InvalidOperationException($"Inode {inodeNumber} is not a regular file or symlink.");
 
+            if (inode.Size < 0)
+                throw new InvalidDataException($"Inode {inodeNumber} has an invalid negative size ({inode.Size}).");
+
             if (inode.Size > int.MaxValue)
                 throw new InvalidOperationException(
                     $"File too large to read into memory ({inode.Size:N0} bytes exceeds {int.MaxValue:N0} byte limit).");
 
-            byte[] data = new byte[inode.Size];
+            byte[] data = new byte[(int)inode.Size];
+            using var ms = new MemoryStream(data, writable: true);
+            ReadFileToStream(inodeNumber, inode, ms, bufferSize: 1024 * 1024);
+            return data;
+        }
+
+        /// <summary>
+        /// Read the entire contents of a regular file or symlink by inode number
+        /// into <paramref name="destination"/> without materializing the whole file
+        /// in memory.
+        /// </summary>
+        public void ReadFile(uint inodeNumber, Stream destination, int bufferSize = 1024 * 1024)
+        {
+            var inode = ReadInode(inodeNumber);
+            ReadFileToStream(inodeNumber, inode, destination, bufferSize);
+        }
+
+        /// <summary>
+        /// Read a byte range from a regular file or symlink by inode number into
+        /// <paramref name="destination"/>. Returns the number of bytes copied.
+        /// This is optimized for random-access callers such as Dokany ReadFile.
+        /// </summary>
+        public long ReadFile(uint inodeNumber, Stream destination, long fileOffset, long count, int bufferSize = 1024 * 1024)
+        {
+            var inode = ReadInode(inodeNumber);
+            return ReadFileRangeToStream(inodeNumber, inode, destination, fileOffset, count, bufferSize);
+        }
+
+        private void ReadFileToStream(uint inodeNumber, Ufs2Inode inode, Stream destination, int bufferSize)
+        {
+            ReadFileRangeToStream(inodeNumber, inode, destination, fileOffset: 0, count: long.MaxValue, bufferSize);
+        }
+
+        private long ReadFileRangeToStream(uint inodeNumber, Ufs2Inode inode, Stream destination, long fileOffset, long count, int bufferSize)
+        {
+            if (destination is null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (!destination.CanWrite)
+                throw new ArgumentException("Destination stream must be writable.", nameof(destination));
+
+            if (!inode.IsRegularFile && !inode.IsSymlink)
+                throw new InvalidOperationException($"Inode {inodeNumber} is not a regular file or symlink.");
+
+            if (inode.Size < 0)
+                throw new InvalidDataException($"Inode {inodeNumber} has an invalid negative size ({inode.Size}).");
+
+            if (fileOffset < 0)
+                throw new ArgumentOutOfRangeException(nameof(fileOffset), "File offset must be non-negative.");
+
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), "Read count must be non-negative.");
+
+            if (count == 0 || fileOffset >= inode.Size)
+                return 0;
+
+            long remaining = Math.Min(count, inode.Size - fileOffset);
+            long copied = 0;
+
+            int actualBufferSize = bufferSize <= 0 ? 1024 * 1024 : bufferSize;
+            actualBufferSize = Math.Min(actualBufferSize, Math.Max(1, Superblock.BSize));
+            byte[] buffer = new byte[actualBufferSize];
+
             long offset = 0;
+            int ptrSize = Superblock.IsUfs1 ? 4 : 8;
+            int pointersPerBlock = Superblock.BSize / ptrSize;
+            long singleIndirectSpan = (long)pointersPerBlock * Superblock.BSize;
+            long doubleIndirectSpan = singleIndirectSpan * pointersPerBlock;
 
             // Direct blocks
             for (int i = 0; i < Ufs2Constants.NDirect && offset < inode.Size; i++)
@@ -262,7 +331,8 @@ namespace UFS2Tool
 
                 if (inode.DirectBlocks[i] == 0)
                 {
-                    // Sparse hole: data is already zero-filled, just advance offset
+                    // Write zeros to stream
+                    WriteZeroes(destination, toAdvance, buffer);
                     offset += toAdvance;
                     continue;
                 }
@@ -270,32 +340,46 @@ namespace UFS2Tool
                 long blockOffset = inode.DirectBlocks[i] * Superblock.FSize;
                 _stream.Position = blockOffset;
 
-                ReadFully(data, (int)offset, (int)toAdvance);
+                CopyFromImageTo(destination, toAdvance, buffer);
                 offset += toAdvance;
             }
 
             // Single indirect
-            if (offset < inode.Size && inode.IndirectBlocks[0] != 0)
+            if (offset < inode.Size)
             {
-                offset = ReadIndirectBlock(inode.IndirectBlocks[0], data, offset, inode.Size);
+                if (inode.IndirectBlocks[0] != 0)
+                    offset = ReadIndirectBlock(inode.IndirectBlocks[0], destination, offset, inode.Size, buffer);
+                else
+                    // Write zeroes to stream
+                    offset = WriteSparseRange(destination, offset, inode.Size, singleIndirectSpan, buffer);
             }
 
             // Double indirect
-            if (offset < inode.Size && inode.IndirectBlocks[1] != 0)
+            if (offset < inode.Size)
             {
-                offset = ReadDoubleIndirectBlock(inode.IndirectBlocks[1], data, offset, inode.Size);
+                if (inode.IndirectBlocks[1] != 0)
+                    offset = ReadDoubleIndirectBlock(inode.IndirectBlocks[1], destination, offset, inode.Size, buffer);
+                else
+                    // Write zeroes to stream
+                    offset = WriteSparseRange(destination, offset, inode.Size, doubleIndirectSpan, buffer);
             }
 
             // Triple indirect
-            if (offset < inode.Size && inode.IndirectBlocks[2] != 0)
+            if (offset < inode.Size)
             {
-                offset = ReadTripleIndirectBlock(inode.IndirectBlocks[2], data, offset, inode.Size);
+                if (inode.IndirectBlocks[2] != 0)
+                    offset = ReadTripleIndirectBlock(inode.IndirectBlocks[2], destination, offset, inode.Size, buffer);
+                else
+                    // Write zeroes to stream
+                    offset = WriteSparseRange(destination, offset, inode.Size, inode.Size - offset, buffer);
             }
 
-            return data;
+            if (offset < inode.Size)
+                throw new InvalidDataException(
+                    $"Inode {inodeNumber} ended before its declared size. Read {offset:N0} of {inode.Size:N0} bytes.");
         }
 
-        private long ReadIndirectBlock(long indirectBlockFrag, byte[] data, long offset, long fileSize)
+        private long ReadIndirectBlock(long indirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
         {
             long blockOffset = indirectBlockFrag * Superblock.FSize;
             _stream.Position = blockOffset;
@@ -306,19 +390,19 @@ namespace UFS2Tool
             for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
             {
                 long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
+                long toAdvance = Math.Min(Superblock.BSize, fileSize - offset);
+
                 if (ptr == 0)
                 {
-                    // Sparse hole: data is already zero-filled, just advance offset
-                    offset += Math.Min(Superblock.BSize, fileSize - offset);
+                    // Write zeros to stream
+                    WriteZeroes(destination, toAdvance, buffer);
+                    offset += toAdvance;
                     continue;
                 }
 
-                long dataOffset = ptr * Superblock.FSize;
-                _stream.Position = dataOffset;
-
-                int toRead = (int)Math.Min(Superblock.BSize, fileSize - offset);
-                ReadFully(data, (int)offset, toRead);
-                offset += toRead;
+                _stream.Position = ptr * Superblock.FSize;
+                CopyFromImageTo(destination, toAdvance, buffer);
+                offset += toAdvance;
 
                 // Restore position for next pointer
                 _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
@@ -327,25 +411,27 @@ namespace UFS2Tool
             return offset;
         }
 
-        private long ReadDoubleIndirectBlock(long doubleIndirectBlockFrag, byte[] data, long offset, long fileSize)
+        private long ReadDoubleIndirectBlock(long doubleIndirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
         {
             long blockOffset = doubleIndirectBlockFrag * Superblock.FSize;
             _stream.Position = blockOffset;
 
             int ptrSize = Superblock.IsUfs1 ? 4 : 8;
             int pointersPerBlock = Superblock.BSize / ptrSize;
+            long indirectSpan = (long)pointersPerBlock * Superblock.BSize;
 
             for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
             {
                 long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
+
                 if (ptr == 0)
                 {
-                    // Sparse hole: skip entire indirect block's worth of data
-                    offset = Math.Min(offset + (long)pointersPerBlock * Superblock.BSize, fileSize);
+                    // Write zeros to stream
+                    offset = WriteSparseRange(destination, offset, fileSize, indirectSpan, buffer);
                     continue;
                 }
 
-                offset = ReadIndirectBlock(ptr, data, offset, fileSize);
+                offset = ReadIndirectBlock(ptr, destination, offset, fileSize, buffer);
 
                 // Restore position for next pointer in the double-indirect block
                 _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
@@ -354,31 +440,65 @@ namespace UFS2Tool
             return offset;
         }
 
-        private long ReadTripleIndirectBlock(long tripleIndirectBlockFrag, byte[] data, long offset, long fileSize)
+        private long ReadTripleIndirectBlock(long tripleIndirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
         {
             long blockOffset = tripleIndirectBlockFrag * Superblock.FSize;
             _stream.Position = blockOffset;
 
             int ptrSize = Superblock.IsUfs1 ? 4 : 8;
             int pointersPerBlock = Superblock.BSize / ptrSize;
+            long doubleIndirectSpan = (long)pointersPerBlock * pointersPerBlock * Superblock.BSize;
 
             for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
             {
                 long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
+
                 if (ptr == 0)
                 {
-                    // Sparse hole: skip entire double-indirect block's worth of data
-                    offset = Math.Min(offset + (long)pointersPerBlock * pointersPerBlock * Superblock.BSize, fileSize);
+                    // Write zeros to stream
+                    offset = WriteSparseRange(destination, offset, fileSize, doubleIndirectSpan, buffer);
                     continue;
                 }
 
-                offset = ReadDoubleIndirectBlock(ptr, data, offset, fileSize);
+                offset = ReadDoubleIndirectBlock(ptr, destination, offset, fileSize, buffer);
 
                 // Restore position for next pointer in the triple-indirect block
                 _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
             }
 
             return offset;
+        }
+
+        private long WriteSparseRange(Stream destination, long offset, long fileSize, long span, byte[] buffer)
+        {
+            long toWrite = Math.Min(span, fileSize - offset);
+            WriteZeroes(destination, toWrite, buffer);
+            return offset + toWrite;
+        }
+
+        private void CopyFromImageTo(Stream destination, long byteCount, byte[] buffer)
+        {
+            long remaining = byteCount;
+            while (remaining > 0)
+            {
+                int toRead = (int)Math.Min(buffer.Length, remaining);
+                ReadFully(buffer, 0, toRead);
+                destination.Write(buffer, 0, toRead);
+                remaining -= toRead;
+            }
+        }
+
+        private static void WriteZeroes(Stream destination, long byteCount, byte[] buffer)
+        {
+            Array.Clear(buffer, 0, buffer.Length);
+
+            long remaining = byteCount;
+            while (remaining > 0)
+            {
+                int toWrite = (int)Math.Min(buffer.Length, remaining);
+                destination.Write(buffer, 0, toWrite);
+                remaining -= toWrite;
+            }
         }
 
         /// <summary>
@@ -806,11 +926,12 @@ namespace UFS2Tool
         /// </summary>
         public void ExtractFile(uint inodeNumber, string outputPath)
         {
-            byte[] data = ReadFile(inodeNumber);
             string? dir = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
-            File.WriteAllBytes(outputPath, data);
+
+            using var output = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024);
+            ReadFile(inodeNumber, output);
         }
 
         /// <summary>
@@ -843,7 +964,7 @@ namespace UFS2Tool
                     var inode = ReadInode(entry.Inode);
                     if (inode.Size > 0 && inode.Size < Superblock.BSize)
                     {
-                        byte[] linkData = ReadFile(entry.Inode);
+                        byte[] linkData = ReadFileBytes(entry.Inode);
                         string target = System.Text.Encoding.UTF8.GetString(linkData).TrimEnd('\0');
                         // Write symlink target as a text file (symlinks may not be supported on host OS)
                         File.WriteAllText(destPath, target);

--- a/Ufs2Image.cs
+++ b/Ufs2Image.cs
@@ -318,162 +318,110 @@ namespace UFS2Tool
             actualBufferSize = Math.Min(actualBufferSize, Math.Max(1, Superblock.BSize));
             byte[] buffer = new byte[actualBufferSize];
 
-            long offset = 0;
-            int ptrSize = Superblock.IsUfs1 ? 4 : 8;
-            int pointersPerBlock = Superblock.BSize / ptrSize;
-            long singleIndirectSpan = (long)pointersPerBlock * Superblock.BSize;
-            long doubleIndirectSpan = singleIndirectSpan * pointersPerBlock;
+            while (remaining > 0)
+            {
+                long logicalOffset = fileOffset + copied;
+                long logicalBlockIndex = logicalOffset / Superblock.BSize;
+                int offsetInBlock = (int)(logicalOffset % Superblock.BSize);
+                long toCopy = Math.Min(remaining, Superblock.BSize - offsetInBlock);
+
+                long dataBlockFrag = ResolveFileDataBlock(inode, logicalBlockIndex);
+                if (dataBlockFrag == 0)
+                {
+                    // Write zeros to stream		
+                    WriteZeroes(destination, toCopy, buffer);
+                }
+                else
+                {
+                    _stream.Position = dataBlockFrag * Superblock.FSize + offsetInBlock;
+                    CopyFromImageTo(destination, toCopy, buffer);
+                }
+
+                copied += toCopy;
+                remaining -= toCopy;
+            }
+
+            return copied;
+        }
+
+        private long ResolveFileDataBlock(Ufs2Inode inode, long logicalBlockIndex)
+        {
+            if (logicalBlockIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(logicalBlockIndex));
 
             // Direct blocks
-            for (int i = 0; i < Ufs2Constants.NDirect && offset < inode.Size; i++)
-            {
-                long toAdvance = Math.Min(Superblock.BSize, inode.Size - offset);
+            if (logicalBlockIndex < Ufs2Constants.NDirect)
+                return inode.DirectBlocks[(int)logicalBlockIndex];
+            logicalBlockIndex -= Ufs2Constants.NDirect;
 
-                if (inode.DirectBlocks[i] == 0)
-                {
-                    // Write zeros to stream
-                    WriteZeroes(destination, toAdvance, buffer);
-                    offset += toAdvance;
-                    continue;
-                }
-
-                long blockOffset = inode.DirectBlocks[i] * Superblock.FSize;
-                _stream.Position = blockOffset;
-
-                CopyFromImageTo(destination, toAdvance, buffer);
-                offset += toAdvance;
-            }
+            int ptrSize = Superblock.IsUfs1 ? 4 : 8;
+            int pointersPerBlock = Superblock.BSize / ptrSize;
+            if (pointersPerBlock <= 0)
+                throw new InvalidDataException($"Invalid block size {Superblock.BSize} for pointer size {ptrSize}.");
 
             // Single indirect
-            if (offset < inode.Size)
+            if (logicalBlockIndex < pointersPerBlock)
             {
-                if (inode.IndirectBlocks[0] != 0)
-                    offset = ReadIndirectBlock(inode.IndirectBlocks[0], destination, offset, inode.Size, buffer);
-                else
-                    // Write zeroes to stream
-                    offset = WriteSparseRange(destination, offset, inode.Size, singleIndirectSpan, buffer);
+                if (inode.IndirectBlocks[0] == 0)
+                    return 0;
+
+                return ReadBlockPointer(inode.IndirectBlocks[0], (int)logicalBlockIndex);
             }
+            logicalBlockIndex -= pointersPerBlock;
 
             // Double indirect
-            if (offset < inode.Size)
+            long doubleIndirectBlockCount = (long)pointersPerBlock * pointersPerBlock;
+            if (logicalBlockIndex < doubleIndirectBlockCount)
             {
-                if (inode.IndirectBlocks[1] != 0)
-                    offset = ReadDoubleIndirectBlock(inode.IndirectBlocks[1], destination, offset, inode.Size, buffer);
-                else
-                    // Write zeroes to stream
-                    offset = WriteSparseRange(destination, offset, inode.Size, doubleIndirectSpan, buffer);
+                if (inode.IndirectBlocks[1] == 0)
+                    return 0;
+
+                int firstIndex = (int)(logicalBlockIndex / pointersPerBlock);
+                int secondIndex = (int)(logicalBlockIndex % pointersPerBlock);
+
+                long singleIndirectFrag = ReadBlockPointer(inode.IndirectBlocks[1], firstIndex);
+                if (singleIndirectFrag == 0)
+                    return 0;
+
+                return ReadBlockPointer(singleIndirectFrag, secondIndex);
             }
+            logicalBlockIndex -= doubleIndirectBlockCount;
 
             // Triple indirect
-            if (offset < inode.Size)
             {
-                if (inode.IndirectBlocks[2] != 0)
-                    offset = ReadTripleIndirectBlock(inode.IndirectBlocks[2], destination, offset, inode.Size, buffer);
-                else
-                    // Write zeroes to stream
-                    offset = WriteSparseRange(destination, offset, inode.Size, inode.Size - offset, buffer);
-            }
+                if (inode.IndirectBlocks[2] == 0)
+                    return 0;
 
-            if (offset < inode.Size)
-                throw new InvalidDataException(
-                    $"Inode {inodeNumber} ended before its declared size. Read {offset:N0} of {inode.Size:N0} bytes.");
+                long doubleIndirectIndexSpan = (long)pointersPerBlock * pointersPerBlock;
+                int outerIndex = (int)(logicalBlockIndex / doubleIndirectIndexSpan);
+                if (outerIndex >= pointersPerBlock)
+                    return 0;
+
+                long innerIndex = logicalBlockIndex % doubleIndirectIndexSpan;
+                int middleIndex = (int)(innerIndex / pointersPerBlock);
+                int leafIndex = (int)(innerIndex % pointersPerBlock);
+
+                long doubleIndirectFrag = ReadBlockPointer(inode.IndirectBlocks[2], outerIndex);
+                if (doubleIndirectFrag == 0)
+                    return 0;
+
+                long singleIndirectFrag2 = ReadBlockPointer(doubleIndirectFrag, middleIndex);
+                if (singleIndirectFrag2 == 0)
+                    return 0;
+
+                return ReadBlockPointer(singleIndirectFrag2, leafIndex);
+            }
         }
 
-        private long ReadIndirectBlock(long indirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
+        private long ReadBlockPointer(long pointerBlockFrag, int pointerIndex)
         {
-            long blockOffset = indirectBlockFrag * Superblock.FSize;
-            _stream.Position = blockOffset;
-
             int ptrSize = Superblock.IsUfs1 ? 4 : 8; // UFS1: 32-bit, UFS2: 64-bit
             int pointersPerBlock = Superblock.BSize / ptrSize;
+            if (pointerIndex < 0 || pointerIndex >= pointersPerBlock)
+                throw new ArgumentOutOfRangeException(nameof(pointerIndex));
 
-            for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
-            {
-                long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
-                long toAdvance = Math.Min(Superblock.BSize, fileSize - offset);
-
-                if (ptr == 0)
-                {
-                    // Write zeros to stream
-                    WriteZeroes(destination, toAdvance, buffer);
-                    offset += toAdvance;
-                    continue;
-                }
-
-                _stream.Position = ptr * Superblock.FSize;
-                CopyFromImageTo(destination, toAdvance, buffer);
-                offset += toAdvance;
-
-                // Restore position for next pointer
-                _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
-            }
-
-            return offset;
-        }
-
-        private long ReadDoubleIndirectBlock(long doubleIndirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
-        {
-            long blockOffset = doubleIndirectBlockFrag * Superblock.FSize;
-            _stream.Position = blockOffset;
-
-            int ptrSize = Superblock.IsUfs1 ? 4 : 8;
-            int pointersPerBlock = Superblock.BSize / ptrSize;
-            long indirectSpan = (long)pointersPerBlock * Superblock.BSize;
-
-            for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
-            {
-                long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
-
-                if (ptr == 0)
-                {
-                    // Write zeros to stream
-                    offset = WriteSparseRange(destination, offset, fileSize, indirectSpan, buffer);
-                    continue;
-                }
-
-                offset = ReadIndirectBlock(ptr, destination, offset, fileSize, buffer);
-
-                // Restore position for next pointer in the double-indirect block
-                _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
-            }
-
-            return offset;
-        }
-
-        private long ReadTripleIndirectBlock(long tripleIndirectBlockFrag, Stream destination, long offset, long fileSize, byte[] buffer)
-        {
-            long blockOffset = tripleIndirectBlockFrag * Superblock.FSize;
-            _stream.Position = blockOffset;
-
-            int ptrSize = Superblock.IsUfs1 ? 4 : 8;
-            int pointersPerBlock = Superblock.BSize / ptrSize;
-            long doubleIndirectSpan = (long)pointersPerBlock * pointersPerBlock * Superblock.BSize;
-
-            for (int i = 0; i < pointersPerBlock && offset < fileSize; i++)
-            {
-                long ptr = Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
-
-                if (ptr == 0)
-                {
-                    // Write zeros to stream
-                    offset = WriteSparseRange(destination, offset, fileSize, doubleIndirectSpan, buffer);
-                    continue;
-                }
-
-                offset = ReadDoubleIndirectBlock(ptr, destination, offset, fileSize, buffer);
-
-                // Restore position for next pointer in the triple-indirect block
-                _stream.Position = blockOffset + ((long)(i + 1) * ptrSize);
-            }
-
-            return offset;
-        }
-
-        private long WriteSparseRange(Stream destination, long offset, long fileSize, long span, byte[] buffer)
-        {
-            long toWrite = Math.Min(span, fileSize - offset);
-            WriteZeroes(destination, toWrite, buffer);
-            return offset + toWrite;
+            _stream.Position = pointerBlockFrag * Superblock.FSize + (long)pointerIndex * ptrSize;
+            return Superblock.IsUfs1 ? _reader.ReadInt32() : _reader.ReadInt64();
         }
 
         private void CopyFromImageTo(Stream destination, long byteCount, byte[] buffer)


### PR DESCRIPTION
This change is a big one.

The current logic loads an entire file into memory before processing it.  On it's own this is fine for a simple tool, but the problem comes with files larger than Int32.MaxValue, due to how C# handles arrays.  I ran into files with this problem.

The new logic uses streams whenever possible.  It makes some pretty large changes to the data block traversal so this will need review.

Tests have also been altered to use the new stream based read after the old but renamed byte array based read.  The tests use a new construct, a ValidationWriteStream, which is a crude fake stream formed around a byte array that will Assert if the bytes received do not match the underlying array, overflow the length of the underlying array, or if the `AssertComplete` function is called do not visit all array indexes.

These changes were made for my own purposes where I needed to extract large files from a UFS1 image but I hope they help here too.

Note that Dokany logic was not tested, so be sure to review that.  It was adjusted to use streams and offsets so requests to read parts of files wouldn't need to load the entire file into memory first.  Writing is still restricted to the old ways so this only fixes (but untested) reading large files.