### PR TITLE
Try multiple common superblock offsets when loading UFS image

### DIFF
--- a/UFS2Tool.Tests/BitmapAndLinkCountTests.cs
+++ b/UFS2Tool.Tests/BitmapAndLinkCountTests.cs
@@ -109,7 +109,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             long sbTotalFreeBlocks = 0;
@@ -415,7 +415,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sbRaw = Ufs2Superblock.ReadFrom(reader);
 
             long sumFreeBlocks = 0, sumFreeFrags = 0;
@@ -928,7 +928,7 @@ namespace UFS2Tool.Tests
             // Check 3: CG bitmaps match summary counts
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sbRaw = Ufs2Superblock.ReadFrom(reader);
 
             long sumFreeBlocks = 0, sumFreeFrags = 0;

--- a/UFS2Tool.Tests/CylinderGroupTests.cs
+++ b/UFS2Tool.Tests/CylinderGroupTests.cs
@@ -37,7 +37,7 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // Read superblock
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.True(sb.ContigSumSize > 0, "ContigSumSize should be > 0 for cluster support");
@@ -104,7 +104,7 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // Read superblock
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // CG summary occupies fragments at csAddr
@@ -134,7 +134,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // CG size should include cluster data
@@ -167,7 +167,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Read the CG summary area at CsAddr
@@ -221,7 +221,7 @@ namespace UFS2Tool.Tests
                 using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
                 using var reader = new BinaryReader(fs);
 
-                fs.Position = Ufs2Constants.SuperblockOffset;
+                fs.Position = Ufs2Constants.SuperblockOffset64K;
                 var sb = Ufs2Superblock.ReadFrom(reader);
 
                 long csAreaOffset = sb.CsAddr * sb.FSize;
@@ -283,7 +283,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             for (int cg = 0; cg < sb.NumCylGroups; cg++)
@@ -332,7 +332,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.True(sb.NumCylGroups >= 2, "Need at least 2 CGs for this test");
@@ -392,7 +392,7 @@ namespace UFS2Tool.Tests
                 using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
                 using var reader = new BinaryReader(fs);
 
-                fs.Position = Ufs2Constants.SuperblockOffset;
+                fs.Position = Ufs2Constants.SuperblockOffset64K;
                 var sb = Ufs2Superblock.ReadFrom(reader);
 
                 // Check that backup superblocks match the primary
@@ -433,7 +433,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int expectedIusedoff = Ufs2Constants.CgHeaderBaseSize; // 168 = sizeof(struct cg)

--- a/UFS2Tool.Tests/FsckUfsTests.cs
+++ b/UFS2Tool.Tests/FsckUfsTests.cs
@@ -87,7 +87,7 @@ namespace UFS2Tool.Tests
             using (var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.ReadWrite))
             {
                 // Magic is at offset 0x55C within the superblock, which is at SBLOCK_UFS2 (65536)
-                fs.Position = Ufs2Constants.SuperblockOffset + 0x55C;
+                fs.Position = Ufs2Constants.SuperblockOffset64K + 0x55C;
                 var writer = new BinaryWriter(fs);
                 writer.Write(0xDEADBEEF);
                 writer.Flush();

--- a/UFS2Tool.Tests/NewfsComplianceTests.cs
+++ b/UFS2Tool.Tests/NewfsComplianceTests.cs
@@ -36,7 +36,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.Equal(Ufs2Constants.MaxBSize, sb.MaxBSize);
@@ -55,7 +55,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int expectedMaxContig = Math.Max(1, Ufs2Constants.MaxBSize / sb.BSize);
@@ -75,7 +75,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int expectedContigSumSize = Math.Min(sb.MaxContig, Ufs2Constants.MaxContig);
@@ -95,15 +95,15 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Read fs_sblockactualloc at offset 0x3E0
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x3E0;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x3E0;
             long sblockActualLoc = reader.ReadInt64();
 
-            Assert.Equal(Ufs2Constants.SuperblockOffset, sblockActualLoc);
-            Assert.Equal(Ufs2Constants.SuperblockOffset, sb.SbBlockLoc);
+            Assert.Equal(Ufs2Constants.SuperblockOffset64K, sblockActualLoc);
+            Assert.Equal(Ufs2Constants.SuperblockOffset64K, sb.SbBlockLoc);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             long expectedFreeInodes = (long)sb.NumCylGroups * sb.InodesPerGroup - 3;
@@ -140,7 +140,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             long totalFreeInodes = 0;
@@ -173,7 +173,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.Equal(0, sb.NumClusters);
@@ -192,16 +192,16 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // fs_old_csaddr (0x098) should be set to CsAddr
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x098;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x098;
             int oldCsAddr = reader.ReadInt32();
             Assert.Equal((int)(sb.CsAddr & 0xFFFFFFFF), oldCsAddr);
 
             // fs_old_ncyl (0x0B0) should equal NumCylGroups
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x0B0;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x0B0;
             int oldNcyl = reader.ReadInt32();
             Assert.Equal(sb.NumCylGroups, oldNcyl);
 
@@ -210,7 +210,7 @@ namespace UFS2Tool.Tests
             Assert.Equal(1, oldCpg);
 
             // fs_old_postblformat (0x54C) should be -1 (FS_DYNAMICPOSTBLFMT)
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x54C;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x54C;
             int oldPostblFmt = reader.ReadInt32();
             Assert.Equal(Ufs2Constants.FsDynamicPostblFmt, oldPostblFmt);
 
@@ -233,7 +233,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Per FreeBSD mkfs.c: csfrags = howmany(cssize, fsize) (fragment-aligned)
@@ -465,7 +465,7 @@ namespace UFS2Tool.Tests
                 using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
                 using var reader = new BinaryReader(fs);
 
-                fs.Position = Ufs2Constants.SuperblockOffset;
+                fs.Position = Ufs2Constants.SuperblockOffset64K;
                 var sb = Ufs2Superblock.ReadFrom(reader);
 
                 // Read the root inode to find the root directory data block
@@ -528,7 +528,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             long inodeTableOffset = (long)sb.IblkNo * sb.FSize;
@@ -580,7 +580,7 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // fs_old_flags is at superblock offset 0x0D3 (1 byte)
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x0D3;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x0D3;
             byte oldFlags = reader.ReadByte();
 
             Assert.True((oldFlags & Ufs2Constants.FsFlagsUpdated) != 0,
@@ -602,7 +602,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.True(sb.NumCylGroups > 1, "Need at least 2 CGs for this test");
@@ -657,7 +657,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             long totalFreeBlocks = 0;
@@ -697,7 +697,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Compute CG summary fragment counts (matching FreeBSD formulas)
@@ -763,7 +763,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Simulate fsck pass1: mark metadata and CG summary as used
@@ -862,13 +862,13 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // Read superblock for reference
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Recovery block is at end of sector before SBLOCK_UFS2
             int sectorSize = Ufs2Constants.DefaultSectorSize;
             int recoverySize = 20; // 5 × int32
-            long recoveryOffset = Ufs2Constants.SuperblockOffset - sectorSize + (sectorSize - recoverySize);
+            long recoveryOffset = Ufs2Constants.SuperblockOffset64K - sectorSize + (sectorSize - recoverySize);
 
             fs.Position = recoveryOffset;
             int fsrMagic = reader.ReadInt32();
@@ -902,7 +902,7 @@ namespace UFS2Tool.Tests
             // Recovery block position for UFS2 - should be zeros for UFS1
             int sectorSize = Ufs2Constants.DefaultSectorSize;
             int recoverySize = 20;
-            long recoveryOffset = Ufs2Constants.SuperblockOffset - sectorSize + (sectorSize - recoverySize);
+            long recoveryOffset = Ufs2Constants.SuperblockOffset64K - sectorSize + (sectorSize - recoverySize);
 
             fs.Position = recoveryOffset;
             int fsrMagic = reader.ReadInt32();
@@ -925,7 +925,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int inodeSize = Ufs2Constants.Ufs2InodeSize;
@@ -963,7 +963,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int inodeSize = Ufs2Constants.Ufs2InodeSize;
@@ -995,7 +995,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.Equal(sb.TotalBlocks, sb.ProviderSize);
@@ -1015,7 +1015,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.True(sb.MetaSpace >= 0, "fs_metaspace should be non-negative");
@@ -1038,7 +1038,7 @@ namespace UFS2Tool.Tests
             using var fs = new FileStream(_imagePath, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
 
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             // Read root inode

--- a/UFS2Tool.Tests/NewfsDOptionTests.cs
+++ b/UFS2Tool.Tests/NewfsDOptionTests.cs
@@ -161,7 +161,7 @@ namespace UFS2Tool.Tests
             Assert.True(sb.NumCylGroups >= 1, "Should have at least 1 cylinder group");
             Assert.True(sb.InodesPerGroup > 0, "Should have inodes per group");
             Assert.True(sb.CylGroupSize > 0, "Should have fragments per group");
-            Assert.Equal(Ufs2Constants.SuperblockOffset, sb.SbBlockLoc);
+            Assert.Equal(Ufs2Constants.SuperblockOffset64K, sb.SbBlockLoc);
         }
 
         [Fact]

--- a/UFS2Tool.Tests/SectorSizeNormalizationTests.cs
+++ b/UFS2Tool.Tests/SectorSizeNormalizationTests.cs
@@ -68,7 +68,7 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // fs_fsbtodb is at offset 0x64 (100) in the superblock.
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x64;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x64;
             int fsbtodb = reader.ReadInt32();
 
             // Expected: log2(fsize / DEV_BSIZE) = log2(65536 / 512) = 7.
@@ -92,7 +92,7 @@ namespace UFS2Tool.Tests
             using var reader = new BinaryReader(fs);
 
             // fs_old_nspf is at offset 0x7C (124) in the superblock.
-            fs.Position = Ufs2Constants.SuperblockOffset + 0x7C;
+            fs.Position = Ufs2Constants.SuperblockOffset64K + 0x7C;
             int nspf = reader.ReadInt32();
 
             // Expected: fsize / DEV_BSIZE = 65536 / 512 = 128.
@@ -121,7 +121,7 @@ namespace UFS2Tool.Tests
             // immediately before SBLOCK_UFS2. Recovery sector starts at 65024.
             const int devBsize = 512;
             const int recoverySize = 20;
-            long recoveryOffset = Ufs2Constants.SuperblockOffset - devBsize + (devBsize - recoverySize);
+            long recoveryOffset = Ufs2Constants.SuperblockOffset64K - devBsize + (devBsize - recoverySize);
 
             fs.Position = recoveryOffset;
             int fsrMagic = reader.ReadInt32();
@@ -143,7 +143,7 @@ namespace UFS2Tool.Tests
             // images by relocating the recovery block to offset 61440).
             if (userSectorSize > devBsize)
             {
-                fs.Position = Ufs2Constants.SuperblockOffset - userSectorSize;
+                fs.Position = Ufs2Constants.SuperblockOffset64K - userSectorSize;
                 byte[] preBuf = reader.ReadBytes(userSectorSize - devBsize);
                 foreach (byte b in preBuf)
                     Assert.Equal(0, b);
@@ -179,7 +179,7 @@ namespace UFS2Tool.Tests
             // (0x4B8-0x4BF). All other bytes — including the recovery block,
             // fs_fsbtodb, fs_old_nspf, CG headers, and inode tables — must
             // match exactly.
-            var sbBase = Ufs2Constants.SuperblockOffset;
+            var sbBase = Ufs2Constants.SuperblockOffset64K;
             var allowedRanges = new (long start, long end)[]
             {
                 (sbBase + 0x20, sbBase + 0x23), // fs_old_time
@@ -261,7 +261,7 @@ namespace UFS2Tool.Tests
 
             using var fs = new FileStream(_imagePathA, FileMode.Open, FileAccess.Read);
             using var reader = new BinaryReader(fs);
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             Assert.Equal(Ufs2Constants.Ufs2Magic, sb.Magic);

--- a/UFS2Tool.Tests/TuneFsTests.cs
+++ b/UFS2Tool.Tests/TuneFsTests.cs
@@ -353,7 +353,7 @@ namespace UFS2Tool.Tests
                 using var fs = new FileStream(largePath, FileMode.Open, FileAccess.Read);
                 using var reader = new BinaryReader(fs);
 
-                fs.Position = Ufs2Constants.SuperblockOffset;
+                fs.Position = Ufs2Constants.SuperblockOffset64K;
                 var primary = Ufs2Superblock.ReadFrom(reader);
                 Assert.Equal("BACKUP", primary.VolumeName);
 

--- a/Ufs2Constants.cs
+++ b/Ufs2Constants.cs
@@ -10,15 +10,20 @@ namespace UFS2Tool
     public static class Ufs2Constants
     {
         // Magic numbers
-        public const int Ufs1Magic = 0x00011954;       // UFS1 magic number (FS_UFS1_MAGIC)
-        public const int Ufs2Magic = 0x19540119;       // UFS2 magic number (FS_UFS2_MAGIC)
+        public const int Ufs1Magic = 0x00011954;        // UFS1 magic number (FS_UFS1_MAGIC)
+        public const int Ufs2Magic = 0x19540119;        // UFS2 magic number (FS_UFS2_MAGIC)
         public const int CgMagic = 0x090255;            // Cylinder group magic (CG_MAGIC)
-        public const int SuperblockOffset = 65536;      // SBLOCK_UFS2 superblock offset (64 KB)
+
+        public const int SuperblockOffsetEmbed = 0;     // superblock at start (Tiny/Embedded)
+        public const int SuperblockOffset8K = 8192;     // SBLOCK_UFS1 superblock offset (8 KB)
+        public const int SuperblockOffset64K = 65536;   // SBLOCK_UFS2 superblock offset (64 KB)
+        public const int SuperblockOffset256K = 262144; // extreme bootstrap superblock offset (256 KB)
         public const int SuperblockSize = 8192;         // Superblock size (SBLOCKSIZE)
         public const int MaxMntLen = 468;               // Max mount point length (MAXMNTLEN)
         public const int MaxVolLen = 32;                // Max volume name length (MAXVOLLEN)
         public const int NocsptrsSize = 28;             // NOCSPTRS
         public const int FsIdSize = 2;                  // Filesystem ID size
+        //public const int MagicSuperblockOffset = 0x55C;
 
         // Block sizes
         public const int DefaultBlockSize = 32768;      // 32 KB default block size

--- a/Ufs2Image.cs
+++ b/Ufs2Image.cs
@@ -37,7 +37,7 @@ namespace UFS2Tool
         /// the backup superblock locations printed by newfs/growfs). Mirrors
         /// FreeBSD's <c>fsck_ffs -b block</c> behavior. When
         /// <paramref name="altSuperblockSector"/> is negative the primary superblock
-        /// at <see cref="Ufs2Constants.SuperblockOffset"/> is used.
+        /// at <see cref="Ufs2Constants.SuperblockOffset64K"/> is used.
         /// </summary>
         public Ufs2Image(string imagePath, bool readOnly, long altSuperblockSector)
         {
@@ -52,9 +52,22 @@ namespace UFS2Tool
 
             try
             {
-                long sbOffset = altSuperblockSector >= 0
-                    ? altSuperblockSector * Ufs2Constants.DefaultSectorSize
-                    : Ufs2Constants.SuperblockOffset;
+                long sbOffset = Ufs2Constants.SuperblockOffset64K;
+                if (altSuperblockSector >= 0)
+                {
+                    sbOffset = altSuperblockSector * Ufs2Constants.DefaultSectorSize;
+                }
+                else
+                {
+                    if (CheckForSuperblock(Ufs2Constants.SuperblockOffsetEmbed))
+                        sbOffset = Ufs2Constants.SuperblockOffsetEmbed;
+                    else if (CheckForSuperblock(Ufs2Constants.SuperblockOffset8K))
+                        sbOffset = Ufs2Constants.SuperblockOffset8K;
+                    else if (CheckForSuperblock(Ufs2Constants.SuperblockOffset64K))
+                        sbOffset = Ufs2Constants.SuperblockOffset64K;
+                    else if (CheckForSuperblock(Ufs2Constants.SuperblockOffset256K))
+                        sbOffset = Ufs2Constants.SuperblockOffset256K;
+                }
                 ReadSuperblock(sbOffset);
             }
             catch
@@ -66,7 +79,16 @@ namespace UFS2Tool
             }
         }
 
-        private void ReadSuperblock(long offset = Ufs2Constants.SuperblockOffset)
+        private bool CheckForSuperblock(long offset)
+        {
+            _stream.Position = offset;
+            //_stream.Position += Ufs2Constants.MagicSuperblockOffset;
+            //int Magic = _reader.ReadInt32();
+            var Superblock = Ufs2Superblock.ReadFrom(_reader);
+            return Superblock.IsValid;
+        }
+
+        private void ReadSuperblock(long offset = Ufs2Constants.SuperblockOffset64K)
         {
             if (offset < 0 || offset + Ufs2Constants.SuperblockSize > _stream.Length)
                 throw new InvalidDataException(
@@ -390,7 +412,7 @@ namespace UFS2Tool
             if (IsReadOnly)
                 throw new InvalidOperationException("Cannot write superblock: image is opened read-only.");
 
-            _stream.Position = Ufs2Constants.SuperblockOffset;
+            _stream.Position = Ufs2Constants.SuperblockOffset64K;
             Superblock.WriteTo(Writer);
             Writer.Flush();
         }
@@ -3024,7 +3046,7 @@ namespace UFS2Tool
             sb.MountPoint = "";
 
             // Write primary superblock
-            _stream.Position = Ufs2Constants.SuperblockOffset;
+            _stream.Position = Ufs2Constants.SuperblockOffset64K;
             sb.WriteTo(Writer);
             Writer.Flush();
 

--- a/Ufs2ImageCreator.cs
+++ b/Ufs2ImageCreator.cs
@@ -521,7 +521,7 @@ namespace UFS2Tool
             // Compute CG layout offsets per FreeBSD mkfs.c formulas
             // fs_sblkno: first fragment after boot area + superblock, block-aligned
             int sblkno = AlignUpInt(
-                (Ufs2Constants.SuperblockOffset + Ufs2Constants.SuperblockSize + FragmentSize - 1) / FragmentSize,
+                (Ufs2Constants.SuperblockOffset64K + Ufs2Constants.SuperblockSize + FragmentSize - 1) / FragmentSize,
                 fragsPerBlock);
             // fs_cblkno: CG header follows superblock backup area
             int cblkno = sblkno + AlignUpInt(
@@ -657,7 +657,7 @@ namespace UFS2Tool
                 QFMask = ~((long)fmask),
                 OldInodeFmt = Ufs2Constants.Fs44InodeFmt,
                 MaxFileSize = maxFileSize,
-                SbBlockLoc = Ufs2Constants.SuperblockOffset,
+                SbBlockLoc = Ufs2Constants.SuperblockOffset64K,
                 MaxBSize = maxBSize,
                 ContigSumSize = contigSumSize,
                 // fs_providersize: size of underlying provider in fragments
@@ -670,7 +670,7 @@ namespace UFS2Tool
 
             // Write primary superblock
             byte[] sbData = SerializeSuperblock(superblock);
-            target.WriteAligned(sbData, Ufs2Constants.SuperblockOffset);
+            target.WriteAligned(sbData, Ufs2Constants.SuperblockOffset64K);
 
             // Write UFS2 recovery information block (struct fsrecovery).
             // Per FreeBSD sbin/newfs/mkfs.c: the last 20 bytes of the sector
@@ -799,7 +799,7 @@ namespace UFS2Tool
             // but only accumulates cs_ndir/cs_nbfree/cs_nifree/cs_nffree — cs_numclusters
             // stays 0. FreeBSD's newfs also does not set cs_numclusters in fs_cstotal.
             sbData = SerializeSuperblock(superblock);
-            target.WriteAligned(sbData, Ufs2Constants.SuperblockOffset);
+            target.WriteAligned(sbData, Ufs2Constants.SuperblockOffset64K);
 
             // Update backup superblocks with final counts
             for (int cg = 1; cg < numCylGroups; cg++)
@@ -845,7 +845,7 @@ namespace UFS2Tool
             // The recovery block is in the last sector before SBLOCK_UFS2.
             // struct fsrecovery occupies the last 20 bytes of that sector.
             int recoveryBlockSize = 20; // 5 × int32
-            long sectorBeforeSb = Ufs2Constants.SuperblockOffset - SectorSize;
+            long sectorBeforeSb = Ufs2Constants.SuperblockOffset64K - SectorSize;
             if (sectorBeforeSb < 0) return;
 
             byte[] sector = new byte[SectorSize];
@@ -1740,7 +1740,7 @@ namespace UFS2Tool
                 int inodesPerBlock = BlockSize / inodeSize;
 
                 int sblkno = AlignUpInt(
-                    (Ufs2Constants.SuperblockOffset + Ufs2Constants.SuperblockSize + FragmentSize - 1) / FragmentSize,
+                    (Ufs2Constants.SuperblockOffset64K + Ufs2Constants.SuperblockSize + FragmentSize - 1) / FragmentSize,
                     fragsPerBlock);
                 int cblkno = sblkno + AlignUpInt(
                     (Ufs2Constants.SuperblockSize + FragmentSize - 1) / FragmentSize,
@@ -1818,7 +1818,7 @@ namespace UFS2Tool
                 // Fixed overhead: primary superblock area + CG summary + root directory block
                 int sblockOffset = (FilesystemFormat == 1)
                     ? Ufs2Constants.SuperblockSize
-                    : Ufs2Constants.SuperblockOffset;
+                    : Ufs2Constants.SuperblockOffset64K;
                 long fixedOverhead = AlignUp(sblockOffset + Ufs2Constants.SuperblockSize, BlockSize)
                                    + csSize
                                    + BlockSize;
@@ -1904,7 +1904,7 @@ namespace UFS2Tool
             using var writer = new BinaryWriter(fs);
 
             // Read existing superblock
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             var sb = Ufs2Superblock.ReadFrom(reader);
 
             int fragsPerBlock = sb.BSize / sb.FSize;
@@ -3418,7 +3418,7 @@ namespace UFS2Tool
             // stays 0. FreeBSD's newfs also does not set cs_numclusters in fs_cstotal.
 
             byte[] sbData = SerializeSuperblock(sb);
-            fs.Position = Ufs2Constants.SuperblockOffset;
+            fs.Position = Ufs2Constants.SuperblockOffset64K;
             fs.Write(sbData, 0, sbData.Length);
 
             // Update backup superblocks in each CG (CG > 0)


### PR DESCRIPTION
Now checks for superblock at 0, 8K, 64K, and 256K when in auto mode.  This lets me open all the current UFS1 images I have on hand.